### PR TITLE
Don't set the session category

### DIFF
--- a/modules/juce_audio_devices/native/juce_Audio_ios.cpp
+++ b/modules/juce_audio_devices/native/juce_Audio_ios.cpp
@@ -476,8 +476,8 @@ struct iOSAudioIODevice::Pimpl      : public AsyncUpdater
                             << ", targetBufferSize: " << targetBufferSize);
 
         setAudioSessionActive (true);
-        setAudioSessionCategory (requestedInputChannels > 0 ? AVAudioSessionCategoryPlayAndRecord
-                                                            : AVAudioSessionCategoryPlayback);
+        // setAudioSessionCategory (requestedInputChannels > 0 ? AVAudioSessionCategoryPlayAndRecord
+        //                                                     : AVAudioSessionCategoryPlayback);
         channelData.reconfigure (requestedInputChannels, requestedOutputChannels);
         updateHardwareInfo (true);
         setTargetSampleRateAndBufferSize();

--- a/modules/juce_audio_devices/native/juce_Audio_ios.cpp
+++ b/modules/juce_audio_devices/native/juce_Audio_ios.cpp
@@ -476,6 +476,7 @@ struct iOSAudioIODevice::Pimpl      : public AsyncUpdater
                             << ", targetBufferSize: " << targetBufferSize);
 
         setAudioSessionActive (true);
+        // VOCHLEA - we have removed this because it adds lots of delay on mobile when it changes...
         // setAudioSessionCategory (requestedInputChannels > 0 ? AVAudioSessionCategoryPlayAndRecord
         //                                                     : AVAudioSessionCategoryPlayback);
         channelData.reconfigure (requestedInputChannels, requestedOutputChannels);


### PR DESCRIPTION
In IOS this category change can slow us right down, since we are manually setting a category at the start of the app, and we are continually opening/closing devices, we leave the as `AVAudioSessionCategoryPlayAndRecord` 

Left commented out so we know what's changed easily.